### PR TITLE
4 0 improvments

### DIFF
--- a/NLog.Elmah/NLog.Elmah.csproj
+++ b/NLog.Elmah/NLog.Elmah.csproj
@@ -34,7 +34,7 @@
       <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.0.0\lib\net35\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.0.1\lib\net35\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/NLog.Elmah/NLog.Elmah.nuspec
+++ b/NLog.Elmah/NLog.Elmah.nuspec
@@ -1,22 +1,19 @@
 ﻿<?xml version="1.0"?>
 <package >
-	<metadata>
-		<id>NLog.Elmah</id>
-		<version>$version$</version>
-		<title>NLog.Elmah</title>
-		<authors>NLog, Todd Meinershagen</authors>
-		<owners>NLog</owners>
-		<licenseUrl>https://github.com/NLog/NLog-Contrib/blob/master/LICENSE</licenseUrl>
-		<projectUrl>https://github.com/NLog/NLog.Elmah</projectUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<description>Integrates NLog with ELMAH</description>
-		<releaseNotes>Community contributed custom target for NLog.</releaseNotes>
-		<copyright>Copyright 2013</copyright>
-		<tags>nlog target elmah</tags>
-		<iconUrl>http://nlog-project.org/N.png</iconUrl>
-		<dependencies>
-		<dependency id="NLog" version="3.2.0" />
-		<dependency id="elmah.corelibrary" version="1.2.2" />
-	</dependencies>
-	</metadata>
+  <metadata>
+    <id>NLog.Elmah</id>
+    <version>$version$</version>
+    <title>NLog.Elmah</title>
+    <authors>NLog, Todd Meinershagen</authors>
+    <owners>NLog</owners>
+    <licenseUrl>https://github.com/NLog/NLog-Contrib/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/NLog/NLog.Elmah</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Integrates NLog with ELMAH</description>
+    <releaseNotes>Community contributed custom target for NLog.</releaseNotes>
+    <copyright>Copyright 2013-2016</copyright>
+    <tags>nlog target elmah</tags>
+    <iconUrl>http://nlog-project.org/N.png</iconUrl>
+
+  </metadata>
 </package>

--- a/NLog.Elmah/packages.config
+++ b/NLog.Elmah/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net35" />
-  <package id="NLog" version="4.0.0" targetFramework="net35" />
+  <package id="NLog" version="4.0.1" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
- moved to NLog 4.0.1
- removed `<dependencies>` as AppVeyor will deal with that.
