### PR TITLE
Set Elmah source and user

### DIFF
--- a/NLog.Elmah.Example/NLog.Elmah.Example.csproj
+++ b/NLog.Elmah.Example/NLog.Elmah.Example.csproj
@@ -7,7 +7,7 @@
     <Copyright>Copyright © Microsoft 2015</Copyright>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.0.0" />
+    <PackageReference Include="NLog" Version="4.6.7" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Data.DataSetExtensions" />

--- a/NLog.Elmah.Tests/given_target_with_identitynameasuser_turned_on.cs
+++ b/NLog.Elmah.Tests/given_target_with_identitynameasuser_turned_on.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+using Elmah;
+
+using NLog.Config;
+using NLog.Layouts;
+
+using NUnit.Framework;
+
+namespace NLog.Elmah.Tests.ElmahTargetTests
+{
+	public abstract class given_target_with_identitynameasuser_turned_on
+	{
+		protected ErrorLog ErrorLog;
+		protected readonly DateTime Now = new DateTime(2013, 10, 8, 19, 5, 0);
+
+		[TestFixtureSetUp]
+		public void Init()
+		{
+			ErrorLog = new MemoryErrorLog(1);
+			var loggingConfiguration = new LoggingConfiguration();
+			var target = new ElmahTarget(ErrorLog)
+			{
+				IdentityNameAsUser = true,
+				Layout = new SimpleLayout("${level}-${message}"),
+				GetCurrentDateTime = () => Now
+			};
+
+			loggingConfiguration.LoggingRules.Add(new LoggingRule("*", LogLevel.Debug, target));
+			loggingConfiguration.AddTarget("Elmah", target);
+			LogManager.Configuration = loggingConfiguration;
+		}
+	}
+}

--- a/NLog.Elmah.Tests/given_target_with_identitynameasuser_turned_on_log_event_with_exception_when_logging_error .cs
+++ b/NLog.Elmah.Tests/given_target_with_identitynameasuser_turned_on_log_event_with_exception_when_logging_error .cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Security.Principal;
+using System.Web;
+using NUnit.Framework;
+
+namespace NLog.Elmah.Tests.ElmahTargetTests
+{
+	[TestFixture]
+	public class given_target_with_identitynameasuser_turned_on_log_event_with_exception_when_logging_error : given_target_with_identitynameasuser_turned_on
+	{
+        private string _host;
+
+        [Test]
+        public void should_set_user()
+        {
+            HttpContext.Current = GetContext();
+            LogManager.GetLogger("Test").Error(new Exception(), "An exception");
+            var error = ErrorLog.GetFirstError();
+			Assert.That(error.User, Is.EqualTo("UserName"));
+		}
+
+        private HttpContext GetContext()
+        {
+            const string appVirtualDir = "/";
+            const string appPhysicalDir = @"c:\\projects\\SubtextSystem\\Subtext.Web\\";
+            const string page = "application/default.aspx";
+            _host = Environment.MachineName;
+            var query = string.Empty;
+            TextWriter output = null;
+
+            var workerRequest = new SimulatedHttpRequest(appVirtualDir, appPhysicalDir, page, query, output, _host);
+            var ctx = new HttpContext(workerRequest)
+            {
+                User = new GenericPrincipal(new GenericIdentity("UserName"), new string[0])
+            };
+            return ctx;
+        }
+	}
+}

--- a/NLog.Elmah.Tests/given_target_with_loggernameassource_turned_on.cs
+++ b/NLog.Elmah.Tests/given_target_with_loggernameassource_turned_on.cs
@@ -21,7 +21,6 @@ namespace NLog.Elmah.Tests.ElmahTargetTests
 			var loggingConfiguration = new LoggingConfiguration();
 			var target = new ElmahTarget(ErrorLog)
 			{
-				LoggerNameAsSource = true,
 				Layout = new SimpleLayout("${level}-${message}"),
 				GetCurrentDateTime = () => Now
 			};

--- a/NLog.Elmah.Tests/given_target_with_loggernameassource_turned_on.cs
+++ b/NLog.Elmah.Tests/given_target_with_loggernameassource_turned_on.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+using Elmah;
+
+using NLog.Config;
+using NLog.Layouts;
+
+using NUnit.Framework;
+
+namespace NLog.Elmah.Tests.ElmahTargetTests
+{
+	public abstract class given_target_with_loggernameassource_turned_on
+	{
+		protected ErrorLog ErrorLog;
+		protected readonly DateTime Now = new DateTime(2013, 10, 8, 19, 5, 0);
+
+		[TestFixtureSetUp]
+		public void Init()
+		{
+			ErrorLog = new MemoryErrorLog(1);
+			var loggingConfiguration = new LoggingConfiguration();
+			var target = new ElmahTarget(ErrorLog)
+			{
+				LoggerNameAsSource = true,
+				Layout = new SimpleLayout("${level}-${message}"),
+				GetCurrentDateTime = () => Now
+			};
+
+			loggingConfiguration.LoggingRules.Add(new LoggingRule("*", LogLevel.Debug, target));
+			loggingConfiguration.AddTarget("Elmah", target);
+			LogManager.Configuration = loggingConfiguration;
+		}
+	}
+}

--- a/NLog.Elmah.Tests/given_target_with_loggernameassource_turned_on_when_logging_info.cs
+++ b/NLog.Elmah.Tests/given_target_with_loggernameassource_turned_on_when_logging_info.cs
@@ -1,0 +1,24 @@
+﻿using NUnit.Framework;
+
+namespace NLog.Elmah.Tests.ElmahTargetTests
+{
+    [TestFixture]
+    public class given_target_with_loglevelastype_not_set_and_loggernameassource_set_and_log_event_with_no_exception_when_logging_info :
+            given_target_with_loggernameassource_turned_on
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            ErrorLog.Clear();
+            var logger = LogManager.GetLogger("Test");
+            logger.Info("This is an info message.");
+        }
+
+        [Test]
+        public void should_set_source()
+        {
+            var error = ErrorLog.GetFirstError();
+            Assert.That(error.Source, Is.Not.Empty);
+        }
+    }
+}

--- a/NLog.Elmah.Tests/given_target_with_loglevelastype_not_set_and_log_event_with_no_exception_when_logging_info.cs
+++ b/NLog.Elmah.Tests/given_target_with_loglevelastype_not_set_and_log_event_with_no_exception_when_logging_info.cs
@@ -50,6 +50,13 @@ namespace NLog.Elmah.Tests.ElmahTargetTests
 			Assert.That(error.Source, Is.Empty);
 		}
 
+        [Test]
+        public void should_not_set_user()
+        {
+            var error = ErrorLog.GetFirstError();
+            Assert.That(error.User, Is.Empty);
+        }
+
 		[Test]
 		public void should_set_time_to_now()
 		{

--- a/NLog.Elmah.Tests/given_target_with_loglevelastype_not_set_and_log_event_with_no_exception_when_logging_info.cs
+++ b/NLog.Elmah.Tests/given_target_with_loglevelastype_not_set_and_log_event_with_no_exception_when_logging_info.cs
@@ -44,10 +44,10 @@ namespace NLog.Elmah.Tests.ElmahTargetTests
 		}
 
 		[Test]
-		public void should_not_set_source()
+		public void should_set_source()
 		{
 			var error = ErrorLog.GetFirstError();
-			Assert.That(error.Source, Is.Empty);
+			Assert.That(error.Source, Is.EqualTo("Test"));
 		}
 
         [Test]

--- a/NLog.Elmah.Tests/given_target_with_loglevelastype_not_set_log_event_with_exception_when_logging_error.cs
+++ b/NLog.Elmah.Tests/given_target_with_loglevelastype_not_set_log_event_with_exception_when_logging_error.cs
@@ -71,6 +71,13 @@ namespace NLog.Elmah.Tests.ElmahTargetTests
 			Assert.That(error.Source, Is.EqualTo(_exception.Source));
 		}
 
+        [Test]
+        public void should_not_set_user()
+        {
+            var error = ErrorLog.GetFirstError();
+            Assert.That(error.User, Is.Empty);
+        }
+
 		[Test]
 		public void should_set_time_to_now()
 		{

--- a/NLog.Elmah.Tests/given_target_with_loglevelastype_turned_on_and_log_event_with_exception_when_logging_error.cs
+++ b/NLog.Elmah.Tests/given_target_with_loglevelastype_turned_on_and_log_event_with_exception_when_logging_error.cs
@@ -71,6 +71,13 @@ namespace NLog.Elmah.Tests.ElmahTargetTests
 			Assert.That(error.Source, Is.EqualTo(_exception.Source));
 		}
 
+        [Test]
+        public void should_not_set_user()
+        {
+            var error = ErrorLog.GetFirstError();
+            Assert.That(error.User, Is.Empty);
+        }
+
 		[Test]
 		public void should_set_time_to_now()
 		{

--- a/NLog.Elmah/ElmahTarget.cs
+++ b/NLog.Elmah/ElmahTarget.cs
@@ -16,6 +16,7 @@ using System.Web;
 
 
 using Elmah;
+using NLog.Layouts;
 using NLog.Targets;
 
 namespace NLog.Elmah
@@ -36,7 +37,7 @@ namespace NLog.Elmah
         /// <summary>
         /// Use <see cref="LogEventInfo.LoggerName"/> as source if <see cref="LogEventInfo.Exception"/> is <c>null</c>.
         /// </summary>
-        public bool LoggerNameAsSource { get; set; }
+        public Layout Source { get; set; }
 
         /// <summary>
         /// Use <see cref="System.Security.Principal.IIdentity.Name"/> as user.
@@ -58,7 +59,7 @@ namespace NLog.Elmah
 		{
 			_errorLog = errorLog;
 			LogLevelAsType = false;
-			LoggerNameAsSource = false;
+            Source = "${exception:format=Source:whenEmpty=${logger}}";
 		}
 
         /// <summary>
@@ -79,9 +80,7 @@ namespace NLog.Elmah
 			error.Time = GetCurrentDateTime == null ? logEvent.TimeStamp : GetCurrentDateTime();
 			error.HostName = Environment.MachineName;
 			error.Detail = logEvent.Exception == null ? logMessage : logEvent.Exception.StackTrace;
-			error.Source = error.Exception != null
-				? error.Source
-				: LoggerNameAsSource ? logEvent.LoggerName : string.Empty;
+			error.Source = Source.Render(logEvent);
 			error.User = IdentityNameAsUser
 				? httpContext?.User?.Identity?.Name ?? string.Empty
 				: string.Empty;

--- a/NLog.Elmah/ElmahTarget.cs
+++ b/NLog.Elmah/ElmahTarget.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2013 Kim Christensen, Todd Meinershagen, et. al.
+// Copyright 2013 Kim Christensen, Todd Meinershagen, et. al.
 //  
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
 // this file except in compliance with the License. You may obtain a copy of the 
@@ -34,6 +34,16 @@ namespace NLog.Elmah
 		public bool LogLevelAsType { get; set; }
 
         /// <summary>
+        /// Use <see cref="LogEventInfo.LoggerName"/> as source if <see cref="LogEventInfo.Exception"/> is <c>null</c>.
+        /// </summary>
+        public bool LoggerNameAsSource { get; set; }
+
+        /// <summary>
+        /// Use <see cref="System.Security.Principal.IIdentity.Name"/> as user.
+        /// </summary>
+        public bool IdentityNameAsUser { get; set; }
+
+        /// <summary>
         /// Target with default errorlog.
         /// </summary>
 		public ElmahTarget()
@@ -48,6 +58,7 @@ namespace NLog.Elmah
 		{
 			_errorLog = errorLog;
 			LogLevelAsType = false;
+			LoggerNameAsSource = false;
 		}
 
         /// <summary>
@@ -68,6 +79,12 @@ namespace NLog.Elmah
 			error.Time = GetCurrentDateTime == null ? logEvent.TimeStamp : GetCurrentDateTime();
 			error.HostName = Environment.MachineName;
 			error.Detail = logEvent.Exception == null ? logMessage : logEvent.Exception.StackTrace;
+			error.Source = error.Exception != null
+				? error.Source
+				: LoggerNameAsSource ? logEvent.LoggerName : string.Empty;
+			error.User = IdentityNameAsUser
+				? httpContext?.User?.Identity?.Name ?? string.Empty
+				: string.Empty;
 
 			_errorLog.Log(error);
 		}

--- a/NLog.Elmah/NLog.Elmah.csproj
+++ b/NLog.Elmah/NLog.Elmah.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="elmah.corelibrary" Version="1.2.2" />
-    <PackageReference Include="NLog" Version="4.0.1" />
+    <PackageReference Include="NLog" Version="4.6.7" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Web" />

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Example config:
 
 config:
 - `LogLevelAsType`: Use Level as type if logged Exception is `null`.
+- `LoggerNameAsSource`: Use LoggerName as source if logged Exception is `null`.
+- `IdentityNameAsUser`: Use Identity.Name as user.
 
 
 Check the internal log (c:\temp\nlog-interal.txt) in case of problems

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Example config:
 
 config:
 - `LogLevelAsType`: Use Level as type if logged Exception is `null`.
-- `LoggerNameAsSource`: Use LoggerName as source if logged Exception is `null`.
+- `Source`: This layout will be used for rendering the `Elmah.Source` Field. Default is `${exception:format=Source:whenEmpty=${logger}}`
 - `IdentityNameAsUser`: Use Identity.Name as user.
 
 


### PR DESCRIPTION
This PR will add two options: 
- LoggerNameAsSource: will set the loggers name as source 
- IdentityNameAsUser: will set the identity user as user

We wanted to be able to set source and user to the Elmah table, so wie added these two options. Seems related to #7.